### PR TITLE
Drop flake8-isort, the functionality is replaced by isort pre-commit hook

### DIFF
--- a/requirements/syntax.txt
+++ b/requirements/syntax.txt
@@ -1,6 +1,5 @@
 black==21.9b0
 flake8==3.9.2
-flake8-isort==4.0.0
 mypy==0.910
 pre-commit==2.15.0
 types-pkg_resources==0.1.3


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos