### PR TITLE
log as warning watcher error

### DIFF
--- a/platform_neuro_flow_api/watchers.py
+++ b/platform_neuro_flow_api/watchers.py
@@ -36,9 +36,10 @@ class ExecutorAliveWatcher(Watcher):
         if attempt.executor_id:
             try:
                 job = await self._platform_client.jobs.status(attempt.executor_id)
-            except Exception:
-                logger.exception(
-                    f"Failed to check status of executor {attempt.executor_id}"
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to check status of executor {attempt.executor_id}",
+                    exc_info=exc,
                 )
             else:
                 if not job.status.is_finished:


### PR DESCRIPTION
Related to #279 

Temporarily decrease event level to warning as this exception is eating all Sentry quotas

https://sentry.io/organizations/neu-ro/issues/3053165835/?query=is%3Aunresolved&statsPeriod=24h