### PR TITLE
build(deps): bump pyasn1 from 0.6.3 to 0.6.4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2281,14 +2281,14 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps transitive dependency `pyasn1` from 0.6.3 to 0.6.4 to resolve the open Dependabot vulnerability alert (first patched `0.6.4`).

Tracked in Sprinto vulnerability management. Dependabot did not open this one automatically (pyasn1 is transitive, not a direct dependency in `pyproject.toml`), so this is a manual lock-only update.

- File: `poetry.lock` (only pyasn1 changed; no collateral re-resolution)